### PR TITLE
fix(index): remove weird unicode whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
     <header>
       <img class="logo" src="jsunconflogo.svg" alt="JSUnconf" />
       <h2>Hamburg<br /><span class="separator"> </span>April 2016</h2>
-      <h1> This is <strong>your</strong> conference</h1>
+      <h1>This is <strong>your</strong> conference</h1>
     </header>
 
     <!-- Begin MailChimp Signup Form -->


### PR DESCRIPTION
remove a strange unicode whitespace character that did lead to "unknown symbol"-boxes in some clients.
