### PR TITLE
refactor(responsive) finetune responsive behaviour

### DIFF
--- a/CONVENTIONS.MD
+++ b/CONVENTIONS.MD
@@ -1,0 +1,80 @@
+## Git Commit Guidelines
+
+These rules are adopted from [the AngularJS commit conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/).
+
+### Commit Message Format
+
+Each commit message starts with a **type**, a **scope**, and a **subject**.
+
+Below that, the commit message has a **body**.
+
+- **type**: what type of change this commit contains.
+- **scope**: what item of code this commit is changing.
+- **subject**: a short description of the changes.
+- **body** (optional): a more in-depth description of the changes
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+```
+
+Examples:
+```
+feat(ruler): add inches as well as centimeters
+```
+```
+fix(protractor): fix 90 degrees counting as 91 degrees
+```
+```
+refactor(pencil): use graphite instead of lead
+
+Closes #640.
+
+Graphite is a much more available resource than lead, so we use it to lower the price.
+```
+```
+fix(pen): use blue ink instead of red ink
+
+BREAKING CHANGE: Pen now uses blue ink instead of red.
+
+To migrate, change your code from the following:
+
+`pen.draw('blue')`
+
+To:
+
+`pen.draw('red')`
+```
+
+Any line of the commit message should not be longer 100 characters. This allows the message to be easier
+to read on github as well as in various git tools.
+
+### Type
+Is recommended to be one of the below items. Only **feat** and **fix** show up in the changelog, in addition to breaking changes (see breaking changes section at bottom).
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+The scope could be anything specifying place of the commit change. For example `$location`,
+`$browser`, `$compile`, `$rootScope`, `ngHref`, `ngClick`, `ngView`, etc...
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Breaking Changes
+Put any breaking changes with migration instructions in the commit body.
+
+If there is a breaking change, put **BREAKING CHANGE:** in your commit body, and it will show up in the changelog.

--- a/src/styles/_vars.styl
+++ b/src/styles/_vars.styl
@@ -19,6 +19,5 @@ $lightBlue = #338bca
 $backgroundColor = #bbb4b4
 
 
-$mqSmall = '(min-width: 700px)'
-$mqMiddle = '(min-width: 1000px)'
-$mqNormal = '(min-width: 1300px)'
+$mediaQuerySmall = '(min-width: 600px)'
+$mediaQueryBig = '(min-width: 900px)'

--- a/src/styles/base.styl
+++ b/src/styles/base.styl
@@ -27,7 +27,7 @@ html
   font-size: 11px
   tap-highlight-color: rgba(0, 0, 0, 0)
 
-  @media $mqSmall
+  @media $mediaQuerySmall
     font-size: 100%
 
 body
@@ -39,32 +39,12 @@ body
 
   padding: 0 emCalc(25px)
   background: $backgroundColor
-  background-image: url('../images/ticket.jpg'), url('../images/keyvisual.jpg'), url('../images/sponsor.jpg')
-  background-repeat: no-repeat
-  background-position: center 1050px, right 370px, center 1680px
-  background-size: 60%, 80%, 60%
-
   font-family: Raleway, sans-serif
-  line-height: 1.2
   color: $mainFontColor
+  line-height: 1.2
   font-feature-settings: 'kern' 1
 
   min-height: 100%
-
-  @media $mqSmall
-    background-position: center 1600px, right 550px, center 2500px
-    background-size: 60%, 80%, 60%
-
-  @media $mqMiddle
-    background-size: 60%
-
-  @media $mqMiddle
-    background-size: 60%
-    background-position: -100px 600px, calc(100% + 50px) 120px, calc(100% + 50px) 1400px
-
-  @media $mqNormal
-    background-size: auto, auto, auto
-    background-position: -100px emCalc(700px), calc(100% + 50px) 120px, calc(100% + 50px) 1400px
 
 header,
 nav,
@@ -95,7 +75,7 @@ dd:after
 
 button,
 .button
-  font-size: remCalc(18)
+  font-size: remCalc(22)
   display: inline-block
   padding: emCalc(20, 18) emCalc(30, 18)
 
@@ -108,3 +88,6 @@ button,
   letter-spacing: .5px
 
   background: $lighterBlue
+
+  @media $mediaQuerySmall
+    font-size: remCalc(18)

--- a/src/styles/header.styl
+++ b/src/styles/header.styl
@@ -1,5 +1,7 @@
 .main-header
   font-size: 1rem
+
+  position: relative
   display: flex
   flex-direction: column
   align-items: center
@@ -7,17 +9,46 @@
   width: 100%
   margin-bottom: emCalc(40)
 
-  @media $mqMiddle
-    align-items: flex-start
+  @media $mediaQueryBig
+    width: 50%
+    align-self: flex-start
+    align-item: flex-start
+
+  &:before
+    content: ''
+
+    position: absolute
+    top: calc(100% + 20px)
+    right: emCalc(-30)
+
+    width: 150%
+    height: emCalc(600px)
+
+    background-image: url('../images/keyvisual.jpg')
+    background-size: contain
+    background-repeat: no-repeat
+    background-position: right
+
+    z-index: -1
+
+    @media $mediaQuerySmall
+      top: calc(100% + 50px)
+
+    @media $mediaQueryBig
+      top: 0
+      right: calc(-100% - 30px)
 
   &__logo
     max-width: emCalc(160)
     margin-bottom: emCalc(45)
 
   &__title
-    font-size: emCalc(18)
+    font-size: emCalc(24)
     font-weight: 300
     margin-bottom: emCalc(18, 18)
+
+    @media $mediaQuerySmall
+      font-size: emCalc(18)
 
   &__tagline
     font-size: remCalc(56)
@@ -30,7 +61,7 @@
     text-transform: uppercase
     text-align: center
 
-    @media $mqSmall
+    @media $mediaQueryBig
       text-align: left
 
   span

--- a/src/styles/mailchimp.styl
+++ b/src/styles/mailchimp.styl
@@ -5,8 +5,9 @@
   margin: 0 auto
   font-size: 1.5rem
   max-width: 18.75em
-  
-  @media $mqMiddle
+
+  @media $mediaQueryBig
+    align-self: flex-start
     margin: 0
 
   input[type="email"]

--- a/src/styles/nav.styl
+++ b/src/styles/nav.styl
@@ -15,6 +15,3 @@
     align-self: flex-end
     border-top-left-radius: 0
     border-top-right-radius: 0
-
-    @media $mqSmall
-      display: block

--- a/src/styles/section.styl
+++ b/src/styles/section.styl
@@ -1,23 +1,14 @@
 .section
+  font-size: 1rem
   display: flex
 
-  margin-top: emCalc(600)
+  margin-top: emCalc(400)
 
-  @media $mqSmall
-    margin-top: emCalc(600)
-
-  @media $mqMiddle
+  @media $mediaQueryBig
     margin-top: emCalc(100)
-
-  @media $mqNormal
-    margin-top: emCalc(200)
 
   &:last-of-type
     margin-bottom: emCalc(200)
-
-  &--tickets
-    flex-direction: row-reverse
-    padding-left: emCalc(30)
 
   &--date
     justify-content: center
@@ -35,13 +26,16 @@
 
   &__content
     width: 100%
-    text-align: justify
+    text-align: center
 
-    @media $mqMiddle
+    @media $mediaQuerySmall
+      text-align: left
+
+    @media $mediaQueryBig
       width: 50%
 
   &__title
-    font-size: emCalc(40)
+    font-size: emCalc(40, 11)
 
     margin-bottom: emCalc(20, 40)
 
@@ -49,17 +43,21 @@
     text-transform: uppercase
     text-align: center
 
-    @media $mqMiddle
-      text-align: left
+    @media $mediaQuerySmall
+      font-size: emCalc(40)
 
-    span.bold
+    @media $mediaQueryBig
+      text-align: left
+      font-size: emCalc(40)
+
+    .bold
       font-weight: 800
 
-    span.light
+    .light
       font-weight: 100
       text-transform: none
 
-    @media $mqMiddle
+    @media $mediaQuerySmall
       font-size: emCalc(60)
 
   &__subtitle
@@ -68,10 +66,10 @@
     line-height: 2
 
   &__copy
-    text-transfrom: uppercase
-    font-size: emCalc(18)
-    line-height: 2
+    font-size: emCalc(24)
+    line-height: 1.6
 
-
-    @media $mqMiddle
+    @media $mediaQuerySmall
+      font-size: emCalc(18)
+      line-height: 2
       margin-bottom: emCalc(24, 18)

--- a/src/styles/sponsor.styl
+++ b/src/styles/sponsor.styl
@@ -1,23 +1,28 @@
 .sponsor
-  position: absolute
-  left: 0
-  padding-bottom: 500px
-  top: 330vh
+  font-size: 1rem
+  position: relative
+  margin-top: emCalc(500)
 
-  @media $mqSmall
-    top: 250vh
-  @media $mqMiddle
-    padding-bottom: 100px
-    top: 160vh
-    text-align: left
-  @media $mqNormal
-    top: 150vh
-  & .section
-    &__title
-      margin-bottom: emCalc(26, 60)
-    &__subtitle
-      margin: emCalc(30, 18) 0 emCalc(16, 18) 0
-    &__copy
-      line-height: emCalc(34, 18)
-  .button
-    margin: emCalc(24) 0 0 0
+  @media $mediaQueryBig
+    margin-top: emCalc(80)
+
+  &:before
+    content: ''
+
+    position: absolute
+    top: 100%
+
+    width: 100%
+    height: 100%
+
+    background-image: url('../images/sponsor.jpg')
+    background-size: contain
+    background-repeat: no-repeat
+    background-position: center
+
+    z-index: -1
+
+    @media $mediaQueryBig
+      top: 0
+      right: 0
+      width: 50%

--- a/src/styles/ticket.styl
+++ b/src/styles/ticket.styl
@@ -1,4 +1,28 @@
 .tickets
+  position: relative
+  flex-direction: row-reverse
+
+  &:before
+    content: ''
+
+    position: absolute
+    top: calc(100% + 10px)
+    left: 0
+
+    width: 100%
+    height: emCalc(500)
+
+    background-image: url("../images/ticket.jpg")
+    background-size: contain
+    background-repeat: no-repeat
+    background-position: center
+    z-index: -1
+
+    @media $mediaQueryBig
+      top: 0
+      height: 100%
+      width: 50%
+
   &__prices
     & span
       font-weight: 600

--- a/templates/partials/sponsors.jade
+++ b/templates/partials/sponsors.jade
@@ -1,4 +1,4 @@
-section.section.section--sponsors
+section.section.section--sponsors.sponsor
   .section__content
     .section__title How To <br/> become a <br/>
       span.bold Sponsor

--- a/templates/partials/tickets.jade
+++ b/templates/partials/tickets.jade
@@ -1,4 +1,4 @@
-section.section.section--tickets
+section.section.section--tickets.tickets
   .section__content
     .section__title Tickets
 


### PR DESCRIPTION
We should be better of putting the background images in `:before` elements of the corresponding section and position them by hand. Multiple background on the body was a nice idea but difficult to handle. If anyone has a even better solution, step forward! Please check in browser and only merge when things look nice!

The jpg's we are now using are updated in another PR.
- background images are now attached to the responsible section
- lesser mediaqueries
- ajdustments for mediaqueries
